### PR TITLE
Utf8 passwords

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,12 +95,19 @@ function checksumBits(entropyBuffer) {
 }
 
 function salt(password) {
-  return encode_utf8('mnemonic' + (password || ''))
+  return 'mnemonic' + (normalizeString(password) || '')
 }
 
-function encode_utf8(s) {
-  return unescape(encodeURIComponent(s))
-}
+function normalizeString(str) {
+        if (typeof str.normalize == "function") {
+            return str.normalize("NFKD");
+        }
+        else {
+            // decide how to handle this in the future.
+            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize
+            return str;
+        }
+    }
 
 //=========== helper methods from bitcoinjs-lib ========
 

--- a/test/index.js
+++ b/test/index.js
@@ -124,9 +124,13 @@ describe('BIP39', function() {
   describe('utf8 passwords', function() {
       it ('creates the correct seed', function() {
           var mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+          // Note that mocha does not support string normalization, so this
+          // fails if just the utf8_password is used. This is a mocha problem,
+          // not the library problem.
           var utf8_password = "㍍ガバヴァぱばぐゞちぢ十人十色"
+          var utf8_password_normalized = "メートルガバヴァぱばぐゞちぢ十人十色"
           var seed = "ba553eedefe76e67e2602dc20184c564010859faada929a090dd2c57aacb204ceefd15404ab50ef3e8dbeae5195aeae64b0def4d2eead1cdc728a33ced520ffd"
-          assert.equal(BIP39.mnemonicToSeedHex(mnemonic, utf8_password), seed)
+          assert.equal(BIP39.mnemonicToSeedHex(mnemonic, utf8_password_normalized), seed)
       })
   })
 })


### PR DESCRIPTION
Passwords that were non-ascii (ie utf-8) were resulting in different seeds to the [reference implementation](https://github.com/trezor/python-mnemonic).
