### PR TITLE
removed dependency on pbkdf2-compat

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var assert = require('assert')
 var crypto = require('crypto')
-var pbkdf2 = require('pbkdf2-compat').pbkdf2Sync
+var pbkdf2 = crypto.pbkdf2Sync
 var unorm = require('unorm')
 
 var DEFAULT_WORDLIST = require('./wordlists/en.json')

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "license": "ISC",
   "dependencies": {
-    "pbkdf2-compat": "2.0.1",
     "unorm": "^1.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
pbkdf2 functions are available via crypto, both the regular one and crypto-browserify.
Thus pbkdf2-compat is an unnecessary.

Actually, not just unnecessary but harmful, it fails in browserified form due to a circular dependency.
