### PR TITLE
Only generate 128 bit or longer

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,11 @@ JavaScript implementation of [Bitcoin BIP39](https://github.com/bitcoin/bips/blo
 ```javascript
 var bip39 = require('bip39')
 
-var mnemonic = bip39.entropyToMnemonic('133755ff') // hex input, defaults to BIP39 English word list
-// 'basket rival lemon'
+var mnemonic = bip39.entropyToMnemonic('13371337133713371337aabbccddeeff') // hex input, defaults to BIP39 English word list
+// 'basket review soccer chapter illness oppose error vocal rookie group knife wrestle'
 
-
-bip39.mnemonicToEntropy(mnemonic) // hex input, defaults to BIP39 English word list
-// '133755ff'
+bip39.mnemonicToEntropy(mnemonic) // string input, defaults to BIP39 English word list
+// '13371337133713371337aabbccddeeff'
 
 // Generate a random mnemonic using crypto.randomBytes
 mnemonic = bip39.generateMnemonic() // strength defaults to 128 bits

--- a/index.js
+++ b/index.js
@@ -62,6 +62,8 @@ function mnemonicToEntropy (mnemonic, wordlist) {
 function entropyToMnemonic (entropy, wordlist) {
   wordlist = wordlist || DEFAULT_WORDLIST
 
+  assert(entropy.length >= 32, 'Not enough entropy: Minimum 16 bytes')
+
   var entropyBuffer = new Buffer(entropy, 'hex')
   var entropyBits = bytesToBinary([].slice.call(entropyBuffer))
   var checksum = checksumBits(entropyBuffer)


### PR DESCRIPTION
This does not remove the ability to generate seeds for shorter phrases, but it makes sure that people using the library to generate new phrases will adhere to BIP39 standard (which says minimum of 128bits)