### PR TITLE
Remove wordlists from index export

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,16 @@ However, there should be other checks in place, such as checking to make sure th
 
 ```javascript
 var bip39 = require('bip39')
+var wordlist = require('bip39/wordlists/en')
 
-var mnemonic = bip39.entropyToMnemonic('133755ff') // hex input, defaults to BIP39 English word list
+bip39.entropyToMnemonic('133755ff', wordlist) // hex input, BIP39 English word list
 // 'basket rival lemon'
 
-
-bip39.mnemonicToEntropy(mnemonic) // hex input, defaults to BIP39 English word list
+bip39.mnemonicToEntropy(mnemonic, wordlist) // hex input, BIP39 English word list
 // '133755ff'
 
 // Generate a random mnemonic using crypto.randomBytes
-mnemonic = bip39.generateMnemonic() // strength defaults to 128 bits
+bip39.generateMnemonic(wordlist) // strength defaults to 128 bits
 // 'seed sock milk update focus rotate barely fade car face mechanic mercy'
 
 bip39.mnemonicToSeedHex('basket actual')
@@ -38,10 +38,10 @@ bip39.mnemonicToSeedHex('basket actual')
 bip39.mnemonicToSeed('basket actual')
 // <Buffer 5c f2 d4 a8 b0 35 5e 90 29 5b df c5 65 a0 22 a4 09 af 06 3d 53 65 bb 57 bf 74 d9 52 8f 49 4b fa 44 00 f5 3d 83 49 b8 0f da e4 40 82 d7 f9 54 1e 1d ba 2b ...>
 
-bip39.validateMnemonic(mnemonic)
+bip39.validateMnemonic(mnemonic, wordlist)
 // true
 
-bip39.validateMnemonic('basket actual')
+bip39.validateMnemonic('basket actual', wordlist)
 // false
 ```
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ var typeforce = require('typeforce')
 // use unorm until String.prototype.normalize gets better browser support
 var unorm = require('unorm')
 
+var DEFAULT_DELIMITER = ' '
+
 function salt (password) {
   return 'mnemonic' + (password || '')
 }
@@ -31,7 +33,7 @@ function mnemonicToEntropy (mnemonic, wordlist) {
   typeforce(typeforce.String, mnemonic)
   typeforce(typeforce.arrayOf(typeforce.String), wordlist)
 
-  var words = unorm.nfkd(mnemonic).split(' ')
+  var words = unorm.nfkd(mnemonic).split(DEFAULT_DELIMITER)
   assert(words.length % 3 === 0, 'Invalid mnemonic')
 
   var belongToList = words.every(function (word) {
@@ -75,7 +77,7 @@ function entropyToMnemonic (entropy, wordlist, delimiter) {
   typeforce(typeforce.arrayOf('String'), wordlist)
   typeforce('?String', delimiter)
 
-  delimiter = delimiter || ' '
+  delimiter = delimiter || DEFAULT_DELIMITER
 
   var entropyBuffer = new Buffer(entropy, 'hex')
   var entropyBits = bytesToBinary([].slice.call(entropyBuffer))

--- a/index.js
+++ b/index.js
@@ -125,9 +125,5 @@ module.exports = {
   mnemonicToEntropy: mnemonicToEntropy,
   entropyToMnemonic: entropyToMnemonic,
   generateMnemonic: generateMnemonic,
-  validateMnemonic: validateMnemonic,
-  wordlists: {
-    EN: DEFAULT_WORDLIST,
-    JA: JAPANESE_WORDLIST
-  }
+  validateMnemonic: validateMnemonic
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "create-hash": "^1.1.0",
     "pbkdf2": "^3.0.0",
     "randombytes": "^2.0.1",
+    "typeforce": "^1.3.6",
     "unorm": "^1.3.3"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -32,7 +32,7 @@ describe('BIP39', function () {
   describe('mnemonicToEntropy', function () {
     vectors.english.forEach(function (v, i) {
       it('works for tests vector ' + i, function () {
-        assert.equal(BIP39.mnemonicToEntropy(v[1]), v[0])
+        assert.equal(BIP39.mnemonicToEntropy(v[1], wordlists.english), v[0])
       })
     })
 
@@ -52,13 +52,13 @@ describe('BIP39', function () {
   describe('entropyToMnemonic', function () {
     vectors.english.forEach(function (v, i) {
       it('works for tests vector ' + i, function () {
-        assert.equal(BIP39.entropyToMnemonic(v[0]), v[1])
+        assert.equal(BIP39.entropyToMnemonic(v[0], wordlists.english), v[1])
       })
     })
 
     vectors.japanese.forEach(function (v, i) {
       it('works for japanese test vector ' + i, function () {
-        assert.equal(BIP39.entropyToMnemonic(v[0], wordlists.japanese), v[1])
+        assert.equal(BIP39.entropyToMnemonic(v[0], wordlists.japanese, '\u3000'), v[1])
       })
     })
 
@@ -74,19 +74,19 @@ describe('BIP39', function () {
       it('works for tests vector ' + i, function () {
         function rng () { return new Buffer(v[0], 'hex') }
 
-        assert.equal(BIP39.generateMnemonic(undefined, rng), v[1])
+        assert.equal(BIP39.generateMnemonic(wordlists.english, null, rng), v[1])
       })
     })
 
     it('can vary generated entropy bit length', function () {
-      var mnemonic = BIP39.generateMnemonic(96)
+      var mnemonic = BIP39.generateMnemonic(wordlists.english, 96)
       var words = mnemonic.split(' ')
 
       assert.equal(words.length, 9)
     })
 
     it('defaults to randombytes for the RNG', function () {
-      assert.equal(BIP39.generateMnemonic(32), 'imitate robot frequent')
+      assert.equal(BIP39.generateMnemonic(wordlists.english, 32), 'imitate robot frequent')
     })
 
     it('allows a custom RNG to be used', function () {
@@ -96,7 +96,7 @@ describe('BIP39', function () {
         return buffer
       }
 
-      var mnemonic = BIP39.generateMnemonic(64, rng)
+      var mnemonic = BIP39.generateMnemonic(wordlists.english, 64, rng)
       assert.equal(mnemonic, 'advice cage absurd amount doctor act')
     })
 
@@ -107,7 +107,7 @@ describe('BIP39', function () {
         return buffer
       }
 
-      var mnemonic = BIP39.generateMnemonic(64, rng, wordlists.custom)
+      var mnemonic = BIP39.generateMnemonic(wordlists.custom, 64, rng)
       assert.equal(mnemonic, 'adv1c3 cag3 ab5urd am0unt d0ct0r act')
     })
   })
@@ -115,7 +115,7 @@ describe('BIP39', function () {
   describe('validateMnemonic', function () {
     vectors.english.forEach(function (v, i) {
       it('passes check ' + i, function () {
-        assert(BIP39.validateMnemonic(v[1]))
+        assert(BIP39.validateMnemonic(v[1], wordlists.english))
       })
     })
 
@@ -128,16 +128,16 @@ describe('BIP39', function () {
     })
 
     it('fails for mnemonics of wrong length', function () {
-      assert(!BIP39.validateMnemonic('sleep kitten'))
-      assert(!BIP39.validateMnemonic('sleep kitten sleep kitten sleep kitten'))
+      assert(!BIP39.validateMnemonic('sleep kitten', wordlists.english))
+      assert(!BIP39.validateMnemonic('sleep kitten sleep kitten sleep kitten', wordlists.english))
     })
 
     it('fails for mnemonics that contains words not from the word list', function () {
-      assert(!BIP39.validateMnemonic('turtle front uncle idea crush write shrug there lottery flower risky shell'))
+      assert(!BIP39.validateMnemonic('turtle front uncle idea crush write shrug there lottery flower risky shell', wordlists.english))
     })
 
     it('fails for mnemonics of invalid checksum', function () {
-      assert(!BIP39.validateMnemonic('sleep kitten sleep kitten sleep kitten sleep kitten sleep kitten sleep kitten'))
+      assert(!BIP39.validateMnemonic('sleep kitten sleep kitten sleep kitten sleep kitten sleep kitten sleep kitten', wordlists.english))
     })
   })
 
@@ -158,16 +158,16 @@ describe('BIP39', function () {
   describe('Examples in readme', function () {
     var bip39 = BIP39
 
-    var mnemonic = bip39.entropyToMnemonic('133755ff') // hex input, defaults to BIP39 English word list
+    var mnemonic = bip39.entropyToMnemonic('133755ff', wordlists.english) // hex input, defaults to BIP39 English word list
     // 'basket rival lemon'
     assert.ok((/^\w+ \w+ \w+$/).test(mnemonic))
 
-    var temp = bip39.mnemonicToEntropy(mnemonic) // hex input, defaults to BIP39 English word list
+    var temp = bip39.mnemonicToEntropy(mnemonic, wordlists.english) // hex input, defaults to BIP39 English word list
     // '133755ff'
     assert.equal(temp, '133755ff')
 
     // Generate a random mnemonic using crypto.randomBytes
-    mnemonic = bip39.generateMnemonic() // strength defaults to 128 bits
+    mnemonic = bip39.generateMnemonic(wordlists.english) // strength defaults to 128 bits
     // 'bench maximum balance appear cousin negative muscle inform enjoy chief vocal hello'
     assert.ok(/^(\w+ ){11}\w+$/.test(mnemonic))
 
@@ -180,11 +180,11 @@ describe('BIP39', function () {
     assert.equal(buff[0], fiveC)
     // <Buffer 5c f2 d4 a8 b0 35 5e 90 29 5b df c5 65 a0 22 a4 09 af 06 3d 53 65 bb 57 bf 74 d9 52 8f 49 4b fa 44 00 f5 3d 83 49 b8 0f da e4 40 82 d7 f9 54 1e 1d ba 2b ...>
 
-    var bool = bip39.validateMnemonic(mnemonic)
+    var bool = bip39.validateMnemonic(mnemonic, wordlists.english)
     // true
     assert.ok(bool)
 
-    bool = bip39.validateMnemonic('basket actual')
+    bool = bip39.validateMnemonic('basket actual', wordlists.english)
 
     // false
     assert.ok(!bool)

--- a/test/index.js
+++ b/test/index.js
@@ -7,7 +7,8 @@ mock('randombytes', function (size) {
   return new Buffer('qwertyuiopasdfghjklzxcvbnm[];,./'.slice(0, size))
 })
 
-var BIP39 = require('../index.js')
+var BIP39 = require('../index')
+var EN_WORD_LIST = require('../wordlists/en')
 
 var wordlists = {
   english: require('../wordlists/en.json'),
@@ -190,7 +191,7 @@ describe('BIP39', function () {
   })
 
   it('exposes standard wordlists', function () {
-    assert(BIP39.wordlists.EN)
-    assert.equal(BIP39.wordlists.EN.length, 2048)
+    assert(EN_WORD_LIST)
+    assert.equal(EN_WORD_LIST.length, 2048)
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -30,41 +30,22 @@ describe('BIP39', function () {
   })
 
   describe('mnemonicToEntropy', function () {
-    vectors.english.forEach(function (v, i) {
-      it('works for tests vector ' + i, function () {
-        assert.equal(BIP39.mnemonicToEntropy(v[1], wordlists.english), v[0])
-      })
-    })
-
-    vectors.japanese.forEach(function (v, i) {
-      it('works for japanese tests vector ' + i, function () {
-        assert.equal(BIP39.mnemonicToEntropy(v[1], wordlists.japanese), v[0])
-      })
-    })
-
-    vectors.custom.forEach(function (v, i) {
-      it('works for custom test vector ' + i, function () {
-        assert.equal(BIP39.mnemonicToEntropy(v[1], wordlists.custom), v[0])
+    Object.keys(vectors).forEach(function (lang) {
+      vectors[lang].forEach(function (v, i) {
+        it('works for ' + lang + ' tests vector ' + i, function () {
+          assert.equal(BIP39.mnemonicToEntropy(v[1], wordlists[lang]), v[0])
+        })
       })
     })
   })
 
   describe('entropyToMnemonic', function () {
-    vectors.english.forEach(function (v, i) {
-      it('works for tests vector ' + i, function () {
-        assert.equal(BIP39.entropyToMnemonic(v[0], wordlists.english), v[1])
-      })
-    })
-
-    vectors.japanese.forEach(function (v, i) {
-      it('works for japanese test vector ' + i, function () {
-        assert.equal(BIP39.entropyToMnemonic(v[0], wordlists.japanese, '\u3000'), v[1])
-      })
-    })
-
-    vectors.custom.forEach(function (v, i) {
-      it('works for custom test vector ' + i, function () {
-        assert.equal(BIP39.entropyToMnemonic(v[0], wordlists.custom), v[1])
+    Object.keys(vectors).forEach(function (lang) {
+      vectors[lang].forEach(function (v, i) {
+        it('works for ' + lang + ' tests vector ' + i, function () {
+          var delimiter = (lang === 'japanese') ? '\u3000' : null
+          assert.equal(BIP39.entropyToMnemonic(v[0], wordlists[lang], delimiter), v[1])
+        })
       })
     })
   })

--- a/test/index.js
+++ b/test/index.js
@@ -157,17 +157,18 @@ describe('BIP39', function () {
 
   describe('Examples in readme', function () {
     var bip39 = BIP39
+    var wordlist = EN_WORD_LIST
 
-    var mnemonic = bip39.entropyToMnemonic('133755ff', wordlists.english) // hex input, defaults to BIP39 English word list
+    var mnemonic = bip39.entropyToMnemonic('133755ff', wordlist) // hex input, defaults to BIP39 English word list
     // 'basket rival lemon'
     assert.ok((/^\w+ \w+ \w+$/).test(mnemonic))
 
-    var temp = bip39.mnemonicToEntropy(mnemonic, wordlists.english) // hex input, defaults to BIP39 English word list
+    var temp = bip39.mnemonicToEntropy(mnemonic, wordlist) // hex input, defaults to BIP39 English word list
     // '133755ff'
     assert.equal(temp, '133755ff')
 
     // Generate a random mnemonic using crypto.randomBytes
-    mnemonic = bip39.generateMnemonic(wordlists.english) // strength defaults to 128 bits
+    mnemonic = bip39.generateMnemonic(wordlist) // strength defaults to 128 bits
     // 'bench maximum balance appear cousin negative muscle inform enjoy chief vocal hello'
     assert.ok(/^(\w+ ){11}\w+$/.test(mnemonic))
 
@@ -180,11 +181,11 @@ describe('BIP39', function () {
     assert.equal(buff[0], fiveC)
     // <Buffer 5c f2 d4 a8 b0 35 5e 90 29 5b df c5 65 a0 22 a4 09 af 06 3d 53 65 bb 57 bf 74 d9 52 8f 49 4b fa 44 00 f5 3d 83 49 b8 0f da e4 40 82 d7 f9 54 1e 1d ba 2b ...>
 
-    var bool = bip39.validateMnemonic(mnemonic, wordlists.english)
+    var bool = bip39.validateMnemonic(mnemonic, wordlist)
     // true
     assert.ok(bool)
 
-    bool = bip39.validateMnemonic('basket actual', wordlists.english)
+    bool = bip39.validateMnemonic('basket actual', wordlist)
 
     // false
     assert.ok(!bool)

--- a/test/index.js
+++ b/test/index.js
@@ -20,8 +20,6 @@ var vectors = require('./vectors.json')
 
 describe('BIP39', function () {
   describe('mnemonicToSeedHex', function () {
-    this.timeout(20000)
-
     vectors.english.forEach(function (v, i) {
       it('works for tests vector ' + i, function () {
         assert.equal(BIP39.mnemonicToSeedHex(v[1], 'TREZOR'), v[2])


### PR DESCRIPTION
With this change set, there's no longer any default word list. Wordlist become a required argument for all functions previously uses the english wordlist as the default. The special check on Japanese wordlist is replaced by the optional delimiter argument, which default to a regular space.

Also added type checking on the affected functions, alongside basic JSDoc.

This change set is based on discussion in https://github.com/bitcoinjs/bip39/pull/24