### PR TITLE
.travis: drop 0.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: node_js
 before_install:
   - npm install npm -g
 node_js:
-  - "0.10"
-  - "0.11"
   - "0.12"
   - "io.js"
   - "4"


### PR DESCRIPTION
As per `pbkdf2`,  with `0.10` out of LTS, we are dropping support for it.

See https://travis-ci.org/bitcoinjs/bip39/jobs/165215930#L328 showing that should protect users from any issues.