### PR TITLE
Fix spelling of mnemonic "artifact".

### DIFF
--- a/wordlists/english.json
+++ b/wordlists/english.json
@@ -102,7 +102,7 @@
   "arrive",
   "arrow",
   "art",
-  "artefact",
+  "artifact",
   "artist",
   "artwork",
   "ask",


### PR DESCRIPTION
Straightforward change; fixed the spelling of a mnemonic in the English JSON data set.