### PR TITLE
Add function for fixing checksum of a mnemonic

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ bip39.validateMnemonic(mnemonic)
 
 bip39.validateMnemonic('basket actual')
 // => false
+
+bip39.validateMnemonic('add add add add add add add add add add add add')
+// => false
+bip39.fixMnemonicChecksum('add add add add add add add add add add add add')
+// => add add add add add add add add add add add actor
+bip39.validateMnemonic('add add add add add add add add add add add actor')
+// => true
 ```
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -89,6 +89,42 @@ test('validateMnemonic', function (t) {
   t.equal(bip39.validateMnemonic('sleep kitten sleep kitten sleep kitten sleep kitten sleep kitten sleep kitten'), false, 'fails for invalid checksum')
 })
 
+test('fixMnemonicChecksum', function (t) {
+  t.plan(7)
+
+  var fixedMnemonic = bip39.fixMnemonicChecksum('sleep kitten sleep kitten sleep kitten sleep kitten sleep kitten sleep kitten')
+
+  t.equal(fixedMnemonic, 'sleep kitten sleep kitten sleep kitten sleep kitten sleep kitten sleep kid', 'fixes mnemonic')
+  t.equal(bip39.validateMnemonic(fixedMnemonic), true, 'fixed mnemonic passes validity check')
+  t.equal(bip39.fixMnemonicChecksum(fixedMnemonic), fixedMnemonic, 'does nothing with an already valid mnemonic')
+
+  t.throws(function () {
+    bip39.fixMnemonicChecksum('sleep kitten')
+  }, /^Error: Invalid mnemonic$/, 'fails for a mnemonic that is too short')
+
+  t.throws(function () {
+    bip39.fixMnemonicChecksum('sleep kitten sleep kitten sleep kitten')
+  }, /^TypeError: Invalid entropy$/, 'fails for a mnemonic that is too short')
+
+  t.throws(function () {
+    bip39.fixMnemonicChecksum('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about end grace oxygen maze bright face loan ticket trial leg cruel lizard bread worry reject journey perfect chef section caught neither install industry')
+  }, /^TypeError: Invalid entropy$/, 'fails for a mnemonic that is too long')
+
+  t.throws(function () {
+    bip39.fixMnemonicChecksum('turtle front uncle idea crush write shrug there lottery flower risky shell')
+  }, /^Error: Invalid mnemonic$/, 'fails if mnemonic words are not in the word list')
+})
+
+test('fixMnemonicChecksum with non-default wordlist', function (t) {
+  t.plan(3)
+
+  var fixedMnemonic = bip39.fixMnemonicChecksum('あいさつ あいさつ あいさつ あいさつ あいさつ あいさつ あいさつ あいさつ あいさつ あいさつ あいさつ あいさつ', bip39.wordlists.japanese)
+
+  t.equal(fixedMnemonic, 'あいさつ　あいさつ　あいさつ　あいさつ　あいさつ　あいさつ　あいさつ　あいさつ　あいさつ　あいさつ　あいさつ　あそぶ', 'fixes mnemonic')
+  t.equal(bip39.validateMnemonic(fixedMnemonic, bip39.wordlists.japanese), true, 'fixed mnemonic passes validity check')
+  t.equal(bip39.fixMnemonicChecksum(fixedMnemonic, bip39.wordlists.japanese), fixedMnemonic, 'does nothing with an already valid mnemonic')
+})
+
 test('exposes standard wordlists', function (t) {
   t.plan(2)
   t.same(bip39.wordlists.EN, WORDLISTS.english)

--- a/test/readme.js
+++ b/test/readme.js
@@ -41,3 +41,13 @@ test('README example 3', function (t) {
   t.equal(seedHex, '5cf2d4a8b0355e90295bdfc565a022a409af063d5365bb57bf74d9528f494bfa4400f53d8349b80fdae44082d7f9541e1dba2b003bcfec9d0d53781ca676651f')
   t.equal(bip39.validateMnemonic(mnemonic), false)
 })
+
+test('README example 4', function (t) {
+  var mnemonic = 'add add add add add add add add add add add add'
+  var fixedMnemonic = bip39.fixMnemonicChecksum(mnemonic)
+
+  t.plan(3)
+  t.equal(bip39.validateMnemonic(mnemonic), false)
+  t.equal(fixedMnemonic, 'add add add add add add add add add add add actor')
+  t.equal(bip39.validateMnemonic(fixedMnemonic), true)
+})


### PR DESCRIPTION
This PR adds `fixMnemonicChecksum(mnemonic[, wordlist])` function that takes a mnemonic and, if its checksum is invalid, changes the last word to fix that.

This is useful when you want to make a mnemonic you would easily memorize: one cannot just take N arbitrary words from a `bip39` dictionary and call it a day, this would most probably produce a mnemonic with invalid checksum. But this can be easily fixed by changing the last word of a mnemonic, so you get one that is both easily memorizable and valid.

I wrote this code to make a mnemonic for my hardware wallet, but thought it might be useful for others. However, I do not recommend using this for making mnemonics that contain well-known combinations of words or ones that can be guessed by inspecting your public profile or using social engineering. The most safe way to make a mnemonic is to generate a random one.