### PR TITLE
Reduce code duplication with normalize function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,9 @@ const INVALID_ENTROPY = 'Invalid entropy';
 const INVALID_CHECKSUM = 'Invalid mnemonic checksum';
 const WORDLIST_REQUIRED = 'A wordlist is required but a default could not be found.\n' +
     'Please explicitly pass a 2048 word array explicitly.';
+function normalize(str) {
+    return (str || '').normalize('NFKD');
+}
 function lpad(str, padString, length) {
     while (str.length < length)
         str = padString + str;
@@ -33,16 +36,16 @@ function salt(password) {
     return 'mnemonic' + (password || '');
 }
 function mnemonicToSeedSync(mnemonic, password) {
-    const mnemonicBuffer = Buffer.from((mnemonic || '').normalize('NFKD'), 'utf8');
-    const saltBuffer = Buffer.from(salt((password || '').normalize('NFKD')), 'utf8');
+    const mnemonicBuffer = Buffer.from(normalize(mnemonic), 'utf8');
+    const saltBuffer = Buffer.from(salt(normalize(password)), 'utf8');
     return pbkdf2_1.pbkdf2Sync(mnemonicBuffer, saltBuffer, 2048, 64, 'sha512');
 }
 exports.mnemonicToSeedSync = mnemonicToSeedSync;
 function mnemonicToSeed(mnemonic, password) {
     return new Promise((resolve, reject) => {
         try {
-            const mnemonicBuffer = Buffer.from((mnemonic || '').normalize('NFKD'), 'utf8');
-            const saltBuffer = Buffer.from(salt((password || '').normalize('NFKD')), 'utf8');
+            const mnemonicBuffer = Buffer.from(normalize(mnemonic), 'utf8');
+            const saltBuffer = Buffer.from(salt(normalize(password)), 'utf8');
             pbkdf2_1.pbkdf2(mnemonicBuffer, saltBuffer, 2048, 64, 'sha512', (err, data) => {
                 if (err)
                     return reject(err);
@@ -61,7 +64,7 @@ function mnemonicToEntropy(mnemonic, wordlist) {
     if (!wordlist) {
         throw new Error(WORDLIST_REQUIRED);
     }
-    const words = (mnemonic || '').normalize('NFKD').split(' ');
+    const words = normalize(mnemonic).split(' ');
     if (words.length % 3 !== 0)
         throw new Error(INVALID_MNEMONIC);
     // convert word indices to 11 bit binary strings

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -12,6 +12,10 @@ const WORDLIST_REQUIRED =
   'A wordlist is required but a default could not be found.\n' +
   'Please explicitly pass a 2048 word array explicitly.';
 
+function normalize(str?: string): string {
+  return (str || '').normalize('NFKD');
+}
+
 function lpad(str: string, padString: string, length: number): string {
   while (str.length < length) str = padString + str;
   return str;
@@ -43,14 +47,8 @@ export function mnemonicToSeedSync(
   mnemonic: string,
   password?: string,
 ): Buffer {
-  const mnemonicBuffer = Buffer.from(
-    (mnemonic || '').normalize('NFKD'),
-    'utf8',
-  );
-  const saltBuffer = Buffer.from(
-    salt((password || '').normalize('NFKD')),
-    'utf8',
-  );
+  const mnemonicBuffer = Buffer.from(normalize(mnemonic), 'utf8');
+  const saltBuffer = Buffer.from(salt(normalize(password)), 'utf8');
 
   return pbkdf2Sync(mnemonicBuffer, saltBuffer, 2048, 64, 'sha512');
 }
@@ -62,14 +60,8 @@ export function mnemonicToSeed(
   return new Promise(
     (resolve, reject): void => {
       try {
-        const mnemonicBuffer = Buffer.from(
-          (mnemonic || '').normalize('NFKD'),
-          'utf8',
-        );
-        const saltBuffer = Buffer.from(
-          salt((password || '').normalize('NFKD')),
-          'utf8',
-        );
+        const mnemonicBuffer = Buffer.from(normalize(mnemonic), 'utf8');
+        const saltBuffer = Buffer.from(salt(normalize(password)), 'utf8');
         pbkdf2(mnemonicBuffer, saltBuffer, 2048, 64, 'sha512', (err, data) => {
           if (err) return reject(err);
           else return resolve(data);
@@ -90,7 +82,7 @@ export function mnemonicToEntropy(
     throw new Error(WORDLIST_REQUIRED);
   }
 
-  const words = (mnemonic || '').normalize('NFKD').split(' ');
+  const words = normalize(mnemonic).split(' ');
   if (words.length % 3 !== 0) throw new Error(INVALID_MNEMONIC);
 
   // convert word indices to 11 bit binary strings


### PR DESCRIPTION
I noticed when reading through this that there's quite a bit of code duplication for string normalization. Everywhere a string is normalized it's first evaluated as a boolean, then set as an empty string if false, then the resulting string is normalized with `.normalize('NFKD')`.

This PR DRYs up the code with a simpler `normalize(str?)` function that always ensures those actions are taken.

I think it makes the code quite a bit more readable, especially considering the line length wrapping we enforce.

e.g this:

```js
const mnemonicBuffer = Buffer.from(
  (mnemonic || '').normalize('NFKD'),
  'utf8',
);
const saltBuffer = Buffer.from(
  salt((password || '').normalize('NFKD')),
  'utf8',
);
```

becomes this:

```js
const mnemonicBuffer = Buffer.from(normalize(mnemonic), 'utf8');
const saltBuffer = Buffer.from(salt(normalize(password)), 'utf8');
```