### PR TITLE
setEntropyConstraints(min, max)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,8 @@ const pbkdf2_1 = require("pbkdf2");
 const randomBytes = require("randombytes");
 const _wordlists_1 = require("./_wordlists");
 let DEFAULT_WORDLIST = _wordlists_1._default;
+let ENTROPY_MIN = 16;
+let ENTROPY_MAX = 32;
 const INVALID_MNEMONIC = 'Invalid mnemonic';
 const INVALID_ENTROPY = 'Invalid entropy';
 const INVALID_CHECKSUM = 'Invalid mnemonic checksum';
@@ -82,9 +84,9 @@ function mnemonicToEntropy(mnemonic, wordlist) {
     const checksumBits = bits.slice(dividerIndex);
     // calculate the checksum and compare
     const entropyBytes = entropyBits.match(/(.{1,8})/g).map(binaryToByte);
-    if (entropyBytes.length < 16)
+    if (entropyBytes.length < ENTROPY_MIN)
         throw new Error(INVALID_ENTROPY);
-    if (entropyBytes.length > 32)
+    if (entropyBytes.length > ENTROPY_MAX)
         throw new Error(INVALID_ENTROPY);
     if (entropyBytes.length % 4 !== 0)
         throw new Error(INVALID_ENTROPY);
@@ -103,9 +105,9 @@ function entropyToMnemonic(entropy, wordlist) {
         throw new Error(WORDLIST_REQUIRED);
     }
     // 128 <= ENT <= 256
-    if (entropy.length < 16)
+    if (entropy.length < ENTROPY_MIN)
         throw new TypeError(INVALID_ENTROPY);
-    if (entropy.length > 32)
+    if (entropy.length > ENTROPY_MAX)
         throw new TypeError(INVALID_ENTROPY);
     if (entropy.length % 4 !== 0)
         throw new TypeError(INVALID_ENTROPY);
@@ -158,5 +160,18 @@ function getDefaultWordlist() {
     })[0];
 }
 exports.getDefaultWordlist = getDefaultWordlist;
+function setEntropyConstraints(min, max) {
+    if (min <= 0)
+        throw new Error(INVALID_ENTROPY);
+    if (max < min)
+        throw new Error(INVALID_ENTROPY);
+    if (min % 4 !== 0)
+        throw new Error(INVALID_ENTROPY);
+    if (max % 4 !== 0)
+        throw new Error(INVALID_ENTROPY);
+    ENTROPY_MIN = min;
+    ENTROPY_MAX = max;
+}
+exports.setEntropyConstraints = setEntropyConstraints;
 var _wordlists_2 = require("./_wordlists");
 exports.wordlists = _wordlists_2.wordlists;

--- a/test/index.js
+++ b/test/index.js
@@ -90,6 +90,34 @@ test('invalid entropy', function (t) {
   }, /^TypeError: Invalid entropy$/, 'throws for entropy that is larger than 1024')
 })
 
+test('setEntropyConstraints(min, max)', function (t) {
+  t.plan(6)
+
+  t.throws(function () {
+    bip39.setEntropyConstraints(0, 32)
+  }, /^Error: Invalid entropy$/, 'throws for min that\'s equal to 0')
+
+  t.throws(function () {
+    bip39.setEntropyConstraints(-4, 32)
+  }, /^Error: Invalid entropy$/, 'throws for min that\'s less than 0')
+
+  t.throws(function () {
+    bip39.setEntropyConstraints(3, 32)
+  }, /^Error: Invalid entropy$/, 'throws for min that\'s not a multitude of 4 bytes')
+
+  t.throws(function () {
+    bip39.setEntropyConstraints(4, 33)
+  }, /^Error: Invalid entropy$/, 'throws for max that\'s not a multitude of 4 bytes')
+
+  t.throws(function () {
+    bip39.setEntropyConstraints(4, 33)
+  }, /^Error: Invalid entropy$/, 'throws for max that\'s less than min')
+
+  bip39.setEntropyConstraints(8, 32)
+  const mnemonic = bip39.generateMnemonic(64)
+  t.equals(mnemonic.split(' ').length, 6, 'can create mnemonic below default min entropy')
+})
+
 test('UTF8 passwords', function (t) {
   t.plan(vectors.japanese.length * 2)
 

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -5,6 +5,8 @@ import { _default as _DEFAULT_WORDLIST, wordlists } from './_wordlists';
 
 let DEFAULT_WORDLIST: string[] | undefined = _DEFAULT_WORDLIST;
 
+let ENTROPY_MIN = 16;
+let ENTROPY_MAX = 32;
 const INVALID_MNEMONIC = 'Invalid mnemonic';
 const INVALID_ENTROPY = 'Invalid entropy';
 const INVALID_CHECKSUM = 'Invalid mnemonic checksum';
@@ -111,8 +113,8 @@ export function mnemonicToEntropy(
 
   // calculate the checksum and compare
   const entropyBytes = entropyBits.match(/(.{1,8})/g)!.map(binaryToByte);
-  if (entropyBytes.length < 16) throw new Error(INVALID_ENTROPY);
-  if (entropyBytes.length > 32) throw new Error(INVALID_ENTROPY);
+  if (entropyBytes.length < ENTROPY_MIN) throw new Error(INVALID_ENTROPY);
+  if (entropyBytes.length > ENTROPY_MAX) throw new Error(INVALID_ENTROPY);
   if (entropyBytes.length % 4 !== 0) throw new Error(INVALID_ENTROPY);
 
   const entropy = Buffer.from(entropyBytes);
@@ -133,8 +135,8 @@ export function entropyToMnemonic(
   }
 
   // 128 <= ENT <= 256
-  if (entropy.length < 16) throw new TypeError(INVALID_ENTROPY);
-  if (entropy.length > 32) throw new TypeError(INVALID_ENTROPY);
+  if (entropy.length < ENTROPY_MIN) throw new TypeError(INVALID_ENTROPY);
+  if (entropy.length > ENTROPY_MAX) throw new TypeError(INVALID_ENTROPY);
   if (entropy.length % 4 !== 0) throw new TypeError(INVALID_ENTROPY);
 
   const entropyBits = bytesToBinary(Array.from(entropy));
@@ -197,6 +199,15 @@ export function getDefaultWordlist(): string {
       );
     },
   )[0];
+}
+
+export function setEntropyConstraints(min: number, max: number): void {
+  if (min <= 0) throw new Error(INVALID_ENTROPY);
+  if (max < min) throw new Error(INVALID_ENTROPY);
+  if (min % 4 !== 0) throw new Error(INVALID_ENTROPY);
+  if (max % 4 !== 0) throw new Error(INVALID_ENTROPY);
+  ENTROPY_MIN = min;
+  ENTROPY_MAX = max;
 }
 
 export { wordlists } from './_wordlists';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,4 +7,5 @@ export declare function generateMnemonic(strength?: number, rng?: (size: number)
 export declare function validateMnemonic(mnemonic: string, wordlist?: string[]): boolean;
 export declare function setDefaultWordlist(language: string): void;
 export declare function getDefaultWordlist(): string;
+export declare function setEntropyConstraints(min: number, max: number): void;
 export { wordlists } from './_wordlists';


### PR DESCRIPTION
Adds a new function `setEntropyConstraints(min, max)` that can be used to set the minimum and maximum entropy allowed when generating a mnemonic with `generateMnemonic(..)`.