### PR TITLE
Allow matching prefixes of 4 characters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,30 @@ function deriveChecksumBits(entropyBuffer) {
 function salt(password) {
     return 'mnemonic' + (password || '');
 }
+function findWordInWordlist(word, wordlist) {
+    let index;
+    if (word.normalize('NFC').length !== 4) {
+        index = wordlist.indexOf(word);
+        if (index === -1) {
+            throw new Error(INVALID_MNEMONIC);
+        }
+    }
+    else {
+        for (let i = 0; i < wordlist.length; i++) {
+            const w = wordlist[i];
+            if (w.startsWith(word)) {
+                if (index !== undefined) {
+                    throw new Error(INVALID_MNEMONIC);
+                }
+                index = i;
+            }
+        }
+        if (index === undefined) {
+            throw new Error(INVALID_MNEMONIC);
+        }
+    }
+    return index;
+}
 function mnemonicToSeedSync(mnemonic, password) {
     const mnemonicBuffer = Buffer.from(normalize(mnemonic), 'utf8');
     const saltBuffer = Buffer.from(salt(normalize(password)), 'utf8');
@@ -75,10 +99,7 @@ function mnemonicToEntropy(mnemonic, wordlist) {
     // convert word indices to 11 bit binary strings
     const bits = words
         .map((word) => {
-        const index = wordlist.indexOf(word);
-        if (index === -1) {
-            throw new Error(INVALID_MNEMONIC);
-        }
+        const index = findWordInWordlist(word, wordlist);
         return lpad(index.toString(2), '0', 11);
     })
         .join('');

--- a/test/index.js
+++ b/test/index.js
@@ -15,7 +15,7 @@ function testVector (description, wordlist, password, v, i) {
   var vseedHex = v[2]
 
   test('for ' + description + '(' + i + '), ' + ventropy, function (t) {
-    t.plan(6)
+    t.plan(7)
 
     t.equal(bip39.mnemonicToEntropy(vmnemonic, wordlist), ventropy, 'mnemonicToEntropy returns ' + ventropy.slice(0, 40) + '...')
     t.equal(bip39.mnemonicToSeedSync(vmnemonic, password).toString('hex'), vseedHex, 'mnemonicToSeedSync returns ' + vseedHex.slice(0, 40) + '...')
@@ -27,6 +27,9 @@ function testVector (description, wordlist, password, v, i) {
     function rng () { return Buffer.from(ventropy, 'hex') }
     t.equal(bip39.generateMnemonic(undefined, rng, wordlist), vmnemonic, 'generateMnemonic returns RNG entropy unmodified')
     t.equal(bip39.validateMnemonic(vmnemonic, wordlist), true, 'validateMnemonic returns true')
+
+    const smnemonic = vmnemonic.normalize('NFKD').split(' ').map(word => word.normalize('NFC').substr(0, 4)).join(' ');
+    t.equal(bip39.validateMnemonic(smnemonic, wordlist), true, 'validateMnemonic returns true on shorter words')
   })
 }
 

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -69,6 +69,32 @@ function salt(password?: string): string {
   return 'mnemonic' + (password || '');
 }
 
+function findWordInWordlist(word: string, wordlist: string[]): number {
+  let index: number | undefined;
+  if (word.normalize('NFC').length !== 4) {
+    index = wordlist.indexOf(word);
+    if (index === -1) {
+      throw new Error(INVALID_MNEMONIC);
+    }
+  } else {
+    for (let i = 0; i < wordlist.length; i++) {
+      const w = wordlist[i];
+      if (w.startsWith(word)) {
+        if (index !== undefined) {
+          // Should be impossible.
+          throw new Error(INVALID_MNEMONIC);
+        }
+        index = i;
+      }
+    }
+    if (index === undefined) {
+      throw new Error(INVALID_MNEMONIC);
+    }
+  }
+
+  return index;
+}
+
 export function mnemonicToSeedSync(
   mnemonic: string,
   password?: string,
@@ -110,11 +136,7 @@ export function mnemonicToEntropy(
   const bits = words
     .map(
       (word: string): string => {
-        const index = wordlist!.indexOf(word);
-        if (index === -1) {
-          throw new Error(INVALID_MNEMONIC);
-        }
-
+        const index = findWordInWordlist(word, wordlist!);
         return lpad(index.toString(2), '0', 11);
       },
     )


### PR DESCRIPTION
BIP-39 specifies that the wordlist should only contains words that
are different on their first 4 characters, for all words. This allows
to only check the prefixes if the length of a word is 4. Otherwise
the behaviour is unchanged.

This does not seem to impact the performance significantly (I noticed
less than 1% change in runtime of `npm run unit`).